### PR TITLE
エラーハンドリング処理の追加

### DIFF
--- a/src/main/java/com/example/raha/error/ConflictException.java
+++ b/src/main/java/com/example/raha/error/ConflictException.java
@@ -1,0 +1,13 @@
+package com.example.raha.error;
+
+/**
+ * 409エラー用例外クラス
+ *
+ * @author T.Araki
+ */
+public class ConflictException extends RuntimeException {
+
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/raha/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/raha/error/GlobalExceptionHandler.java
@@ -9,17 +9,26 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /**
- * エラーハンドリング共通クラス
+ * エラーハンドリングを実装するクラス
  *
  * @author T.ARAKI
  */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    // 共通エラー処理
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, String>> handleException(Exception e) {
         Map<String, String> response = new HashMap<>();
         response.put("message", "エラーが発生しました");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // 409エラー処理
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<Map<String, String>> conflictException(ConflictException e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
 }

--- a/src/main/java/com/example/raha/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/raha/error/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.raha.error;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * エラーハンドリング共通クラス
+ *
+ * @author T.ARAKI
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleException(Exception e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "エラーが発生しました");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+}

--- a/src/main/java/com/example/raha/repository/UserRepository.java
+++ b/src/main/java/com/example/raha/repository/UserRepository.java
@@ -1,7 +1,6 @@
 package com.example.raha.repository;
 
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;


### PR DESCRIPTION
## 概要 :bulb:

> この変更で何をしたか、簡潔に。

・共通エラーハンドリングの作成（400エラー）
・競合エラーハンドリングの作成（409エラー）

## 観点 :eye:

> レビューで何を見てほしいか。

・実装に問題がないか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

POSTMANにてExceptionエラーを発生させ、400エラー及び想定メッセージが返ってくるか。
ConflictExceptionエラーを発生させて想定エラーが返ってくるか。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

ConfictExceptionにて独自エラー(409用)を作成しました。
例としてメールアドレス重複エラーの場合は throw new ConflictException("メッセージ")を投げれば409エラーが飛ぶようにしています。

その他想定しないエラーの場合はExceptionに飛ぶので400エラーになる想定です。

そのほかで必要なステータスを追加する場合は独自でエラーを作成して追加していく想定で設計しております。