### PR TITLE
【Article】コメントにて、ログイン中のuserIdと記事のuserIdが一致していないと削除できないように変更

### DIFF
--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -48,7 +48,7 @@ public class AuthorizeFilter extends OncePerRequestFilter {
                     .verify(xAuthToken.substring(7));
 
             // デコードされたJWTから "userId" クレームを取得し、ユーザー名として使用
-            String userId = decodedJWT.getClaim("userId").toString();
+            Integer userId = Integer.parseInt(decodedJWT.getClaim("userId").toString());
 
             // 認証情報を作成し、セキュリティコンテキストに設定
             SecurityContextHolder.getContext()

--- a/src/main/java/com/example/raha/controller/ArticleController.java
+++ b/src/main/java/com/example/raha/controller/ArticleController.java
@@ -108,13 +108,11 @@ public class ArticleController {
     @DeleteMapping("/{articleId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Integer articleId) {
-        String userIdText = (String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        if (userIdText == null) {
+        Integer userId = (Integer) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (userId == null) {
             return;
         }
-        Integer userId = Integer.parseInt(userIdText);
         articleService.delete(articleId, userId);
-
     }
 
 }

--- a/src/main/java/com/example/raha/controller/CommentController.java
+++ b/src/main/java/com/example/raha/controller/CommentController.java
@@ -20,6 +20,7 @@ import java.net.URI;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 
 /**
@@ -73,6 +74,11 @@ public class CommentController {
     @DeleteMapping("/{commentId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteComment(@PathVariable Integer commentId) {
-        commentService.delete(commentId);
+        Integer userId = (Integer)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        System.out.println(userId);
+        if (userId == null) {
+            return;
+        }
+        commentService.delete(commentId, userId);
     }
 }

--- a/src/main/java/com/example/raha/controller/CommentController.java
+++ b/src/main/java/com/example/raha/controller/CommentController.java
@@ -75,7 +75,6 @@ public class CommentController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteComment(@PathVariable Integer commentId) {
         Integer userId = (Integer)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        System.out.println(userId);
         if (userId == null) {
             return;
         }

--- a/src/main/java/com/example/raha/repository/CommentRepository.java
+++ b/src/main/java/com/example/raha/repository/CommentRepository.java
@@ -53,17 +53,18 @@ public class CommentRepository {
                 .addValue("content", comment.getContent())
                 .addValue("id", commentId)
                 .addValue("updatedAt", now);
-                jdbcTemplate.update(sql, param);
+        jdbcTemplate.update(sql, param);
     }
 
     /**
      * コメント情報削除
      * 
      * @param commentId コメントID
+     * @param userId ユーザーID
      */
-    public void delete(Integer commentId) {
-        String sql = "DELETE FROM comments WHERE id = :id";
-        SqlParameterSource param = new MapSqlParameterSource().addValue("id", commentId);
+    public void delete(Integer commentId, Integer userId) {
+        String sql = "DELETE FROM comments WHERE id = :id AND user_id=:userId";
+        SqlParameterSource param = new MapSqlParameterSource().addValue("id", commentId).addValue("userId", userId);
         jdbcTemplate.update(sql, param);
     }
 }

--- a/src/main/java/com/example/raha/service/CommentService.java
+++ b/src/main/java/com/example/raha/service/CommentService.java
@@ -45,7 +45,7 @@ public class CommentService {
      * 
      * @param commentId コメントID
      */
-    public void delete(Integer commentId) {
-        commentRepository.delete(commentId);
+    public void delete(Integer commentId, Integer userId) {
+        commentRepository.delete(commentId, userId);
     }
 }


### PR DESCRIPTION
## 概要 :bulb:

> この変更で何をしたか、簡潔に。

ログイン中のuserIdと記事のuserIdが一致していないと削除できないように変更

## 観点 :eye:

> レビューで何を見てほしいか。

ログイン中のuserIdと記事のuserIdが一致していないと削除できないように変更できているかどうか
ログインしていない(X-AUTH-TOKENなし)の場合該当の記事が削除できず、204ステータス成功と表示されるように変更

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

パターン①
①下記サイトにてuserIdを1にしてJWTを発行
https://jwt.io/
②POSTMANのDELETEでHeaderにJWTを入れて実行
③204が出て削除できていればOK

パターン②
①下記サイトにてuserIdを2にしてJWTを発行
https://jwt.io/
②POSTMANのDELETEでHeaderにJWTを入れて実行
③204は出るが削除できていなければOK

## 関連する Issue :memo:

> 関連する Issue へのリンク。

http://18.183.155.92/issues/120

## 補足情報 :notes:

> 補足情報があれば記載。