### PR TITLE
【認証エラー関連】認証エラーの例外処理を追加しました

### DIFF
--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -58,7 +58,7 @@ public class AuthorizeFilter extends OncePerRequestFilter {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.setContentType("application/json");
                 response.setCharacterEncoding("UTF-8");
-                response.getWriter().write("{\"message\":\"ログインしてください\"}");
+                response.getWriter().write("{\"message\":\"ログインしてください。\"}");
                 return;
             }
 
@@ -83,7 +83,7 @@ public class AuthorizeFilter extends OncePerRequestFilter {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.setContentType("application/json");
                 response.setCharacterEncoding("UTF-8");
-                response.getWriter().write("{\"message\":\"ログインしてください。\"}");
+                response.getWriter().write("{\"message\":\"認証に失敗しました。再度ログインしてください。\"}");
                 return;
             }
         }

--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -34,8 +35,8 @@ public class AuthorizeFilter extends OncePerRequestFilter {
             Arrays.asList(
                 new AntPathRequestMatcher("/login"),
                 new AntPathRequestMatcher("/register"),
-                new AntPathRequestMatcher("/articles/*"),
-                new AntPathRequestMatcher("/articles")
+                new AntPathRequestMatcher("/articles/*", HttpMethod.GET.name()),
+                new AntPathRequestMatcher("/articles", HttpMethod.GET.name())
             )
         );
     }

--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -35,8 +35,8 @@ public class AuthorizeFilter extends OncePerRequestFilter {
             Arrays.asList(
                 new AntPathRequestMatcher("/login"),
                 new AntPathRequestMatcher("/register"),
-                new AntPathRequestMatcher("/articles/*", HttpMethod.GET.name()),
-                new AntPathRequestMatcher("/articles", HttpMethod.GET.name())
+                new AntPathRequestMatcher("/articles/*", HttpMethod.GET.toString()),
+                new AntPathRequestMatcher("/articles", HttpMethod.GET.toString())
             )
         );
     }

--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -45,17 +45,17 @@ public class AuthorizeFilter extends OncePerRequestFilter {
                 return;
             }
 
-            // トークンの "Bearer " 部分を取り除き、実際のトークンを取得
             try {
-            DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(secret)).build()
-                    .verify(xAuthToken.substring(7));
+                // トークンの "Bearer " 部分を取り除き、実際のトークンを取得
+                DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(secret)).build()
+                        .verify(xAuthToken.substring(7));
 
-            // デコードされたJWTから "userId" クレームを取得し、ユーザー名として使用
-            String userId = decodedJWT.getClaim("userId").toString();
+                // デコードされたJWTから "userId" クレームを取得し、ユーザー名として使用
+                String userId = decodedJWT.getClaim("userId").toString();
 
-            // 認証情報を作成し、セキュリティコンテキストに設定
-            SecurityContextHolder.getContext()
-                    .setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, new ArrayList<>()));
+                // 認証情報を作成し、セキュリティコンテキストに設定
+                SecurityContextHolder.getContext()
+                        .setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, new ArrayList<>()));
             } catch (TokenExpiredException e) {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.setContentType("application/json");

--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -24,7 +24,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 @Component
 public class AuthorizeFilter extends OncePerRequestFilter {
-    private final AntPathRequestMatcher matcher = new AntPathRequestMatcher("login");
+    private final AntPathRequestMatcher matcher = new AntPathRequestMatcher("/login");
 
     @Autowired
     @Value("${jwt.secret}")
@@ -66,7 +66,7 @@ public class AuthorizeFilter extends OncePerRequestFilter {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.setContentType("application/json");
                 response.setCharacterEncoding("UTF-8");
-                response.getWriter().write("{\"message\":\"認証に失敗しました。再度ログインしてください。\"}");
+                response.getWriter().write("{\"message\":\"ログインしてください。\"}");
                 return;
             }
         }

--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -13,6 +13,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 
 import jakarta.servlet.FilterChain;
@@ -54,11 +56,17 @@ public class AuthorizeFilter extends OncePerRequestFilter {
             // 認証情報を作成し、セキュリティコンテキストに設定
             SecurityContextHolder.getContext()
                     .setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, new ArrayList<>()));
-            } catch (Exception e) {
+            } catch (TokenExpiredException e) {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.setContentType("application/json");
                 response.setCharacterEncoding("UTF-8");
-                response.getWriter().write("{\"message\":\"Unauthorized\"}");
+                response.getWriter().write("{\"message\":\"セッションが切れました。再度ログインしてください。\"}");
+                return;
+            } catch (JWTVerificationException e) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
+                response.getWriter().write("{\"message\":\"認証に失敗しました。再度ログインしてください。\"}");
                 return;
             }
         }

--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -2,12 +2,15 @@ package com.example.raha.config;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -24,7 +27,18 @@ import jakarta.servlet.http.HttpServletResponse;
 
 @Component
 public class AuthorizeFilter extends OncePerRequestFilter {
-    private final AntPathRequestMatcher matcher = new AntPathRequestMatcher("/login");
+    private final RequestMatcher matcher;
+    
+    public AuthorizeFilter() {
+        this.matcher = new OrRequestMatcher(
+            Arrays.asList(
+                new AntPathRequestMatcher("/login"),
+                new AntPathRequestMatcher("/register"),
+                new AntPathRequestMatcher("/articles/*"),
+                new AntPathRequestMatcher("/articles")
+            )
+        );
+    }
 
     @Autowired
     @Value("${jwt.secret}")
@@ -39,9 +53,12 @@ public class AuthorizeFilter extends OncePerRequestFilter {
             // リクエストヘッダーから "X-AUTH-TOKEN" を取得
             String xAuthToken = request.getHeader("X-AUTH-TOKEN");
 
-            // トークンが存在しないか、"Bearer " で始まらない場合はフィルタをスキップ
+            // トークンが存在しないか、"Bearer " で始まらない場合はエラーメッセージをレスポンス
             if (xAuthToken == null || !xAuthToken.startsWith("Bearer ")) {
-                filterChain.doFilter(request, response); // 次のフィルタまたはリソースに処理を渡す
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
+                response.getWriter().write("{\"message\":\"ログインしてください！\"}");
                 return;
             }
 

--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -44,6 +44,7 @@ public class AuthorizeFilter extends OncePerRequestFilter {
             }
 
             // トークンの "Bearer " 部分を取り除き、実際のトークンを取得
+            try {
             DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(secret)).build()
                     .verify(xAuthToken.substring(7));
 
@@ -53,6 +54,13 @@ public class AuthorizeFilter extends OncePerRequestFilter {
             // 認証情報を作成し、セキュリティコンテキストに設定
             SecurityContextHolder.getContext()
                     .setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, new ArrayList<>()));
+            } catch (Exception e) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
+                response.getWriter().write("{\"message\":\"Unauthorized\"}");
+                return;
+            }
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -58,7 +58,7 @@ public class AuthorizeFilter extends OncePerRequestFilter {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.setContentType("application/json");
                 response.setCharacterEncoding("UTF-8");
-                response.getWriter().write("{\"message\":\"ログインしてください！\"}");
+                response.getWriter().write("{\"message\":\"ログインしてください\"}");
                 return;
             }
 

--- a/src/main/java/com/example/raha/config/SecurityConfig.java
+++ b/src/main/java/com/example/raha/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(authz -> authz
                 .requestMatchers("/login", "/register").permitAll()
-                .requestMatchers(HttpMethod.GET, "/articles/*").permitAll()
+                .requestMatchers(HttpMethod.GET,"/articles", "/articles/*").permitAll()
                 .anyRequest().authenticated());
 
         // カスタムの認可フィルタをセキュリティフィルタチェーンに追加

--- a/src/main/java/com/example/raha/controller/AccountController.java
+++ b/src/main/java/com/example/raha/controller/AccountController.java
@@ -18,8 +18,6 @@ import com.example.raha.form.LoginForm;
 import com.example.raha.service.UserService;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 
 /**

--- a/src/main/java/com/example/raha/controller/AccountController.java
+++ b/src/main/java/com/example/raha/controller/AccountController.java
@@ -19,7 +19,6 @@ import com.example.raha.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
-
 /**
  * アカウントコントローラー
  * 

--- a/src/main/java/com/example/raha/controller/AccountController.java
+++ b/src/main/java/com/example/raha/controller/AccountController.java
@@ -18,6 +18,9 @@ import com.example.raha.form.LoginForm;
 import com.example.raha.service.UserService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
 
 /**
  * アカウントコントローラー


### PR DESCRIPTION
## 概要 :bulb:
JWT有効期限切れの場合
その他のJWT認証エラー発生時

上記例外発生時の例外処理を作成しました。

## 観点 :eye:

- 有効期限切れのJWTを使って認証が必要な処理を行った場合に401エラーとセッション切れの旨のメッセージが返ること

- その他の認証エラー(アルゴリズム変更など)を行った場合に401エラーと認証失敗の旨のメッセージが返ること

## 関連する Issue :memo:

http://18.183.155.92/issues/128?issue_count=58&issue_position=1&next_issue_id=127
