### PR TITLE
【Article】コメント更新の際にuserIdが一致していないと更新できないように再度実装

### DIFF
--- a/src/main/java/com/example/raha/controller/CommentController.java
+++ b/src/main/java/com/example/raha/controller/CommentController.java
@@ -64,12 +64,13 @@ public class CommentController {
     @PutMapping("/{commentId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateComment(@RequestBody CommentForm comment, @PathVariable Integer commentId) {
-        commentService.update(comment, commentId);
+        Integer userId = (Integer)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        commentService.update(comment, commentId, userId);
     }
     /**
      * コメントの削除
      * 
-     * @param commentId
+     * @param commentId コメントID
      */
     @DeleteMapping("/{commentId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/example/raha/repository/CommentRepository.java
+++ b/src/main/java/com/example/raha/repository/CommentRepository.java
@@ -46,13 +46,14 @@ public class CommentRepository {
      * 
      * @param comment コメント情報
      */
-    public void update(CommentForm comment, Integer commentId) {
-        String sql = "UPDATE comments SET content=:content, updated_at=:updatedAt WHERE id=:id";
+    public void update(CommentForm comment, Integer commentId, Integer userId) {
+        String sql = "UPDATE comments SET content=:content, updated_at=:updatedAt WHERE id=:id AND user_id=:userId";
         LocalDateTime now = LocalDateTime.now();
         SqlParameterSource param = new MapSqlParameterSource()
                 .addValue("content", comment.getContent())
                 .addValue("id", commentId)
-                .addValue("updatedAt", now);
+                .addValue("updatedAt", now)
+                .addValue("userId", userId);
         jdbcTemplate.update(sql, param);
     }
 

--- a/src/main/java/com/example/raha/service/CommentService.java
+++ b/src/main/java/com/example/raha/service/CommentService.java
@@ -36,8 +36,8 @@ public class CommentService {
      * @param comment コメント情報
      * @param commentId 更新するコメントID
      */
-    public void update(CommentForm comment, Integer commentId) {
-        commentRepository.update(comment, commentId);
+    public void update(CommentForm comment, Integer commentId, Integer userId) {
+        commentRepository.update(comment, commentId, userId);
     }
     
     /**


### PR DESCRIPTION
## 概要 :bulb:

> この変更で何をしたか、簡潔に。

コメント更新の際にuserIdが一致していないと更新できないように再度実装

## 観点 :eye:

> レビューで何を見てほしいか。

コメントが認証していないと変更できないか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

★認証ありパターン
①POSTMANのPUTの下記のURLを記入
http://localhost:8080/comments/1
②Bodyに下記を記入
{    
   "content" : "change content"
}

③Headerに下記を記入（1/22の10時34分まで有効）
・X-AUTH-TOKEN
・Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImV4cCI6MTczNzUwOTY0M30.kew8kGSkzohQiuQE5anEFTDw_wLb9pf7Qius-1NSxyk
④実行し、コメントidの1が"change content"になっているかを確認

★認証なしパターン
上記のテストの②の際にX-AUTH-TOKENのチェックを外して実行
→403エラーが出ればOK

## 関連する Issue :memo:

> 関連する Issue へのリンク。

http://18.183.155.92/issues/130


## 補足情報 :notes:

> 補足情報があれば記載。