### PR TITLE
【User】メール重複API追加

### DIFF
--- a/src/main/java/com/example/raha/config/AuthorizeFilter.java
+++ b/src/main/java/com/example/raha/config/AuthorizeFilter.java
@@ -35,6 +35,7 @@ public class AuthorizeFilter extends OncePerRequestFilter {
             Arrays.asList(
                 new AntPathRequestMatcher("/login"),
                 new AntPathRequestMatcher("/register"),
+                new AntPathRequestMatcher("/check-email"),
                 new AntPathRequestMatcher("/articles/*", HttpMethod.GET.toString()),
                 new AntPathRequestMatcher("/articles", HttpMethod.GET.toString())
             )

--- a/src/main/java/com/example/raha/config/SecurityConfig.java
+++ b/src/main/java/com/example/raha/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
         http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
 
         http.authorizeHttpRequests(authz -> authz
-                .requestMatchers("/login", "/register").permitAll()
+                .requestMatchers("/login", "/register", "/check-email").permitAll()
                 .requestMatchers(HttpMethod.GET,"/articles", "/articles/*").permitAll()
                 .anyRequest().authenticated());
 

--- a/src/main/java/com/example/raha/controller/AccountController.java
+++ b/src/main/java/com/example/raha/controller/AccountController.java
@@ -2,6 +2,7 @@ package com.example.raha.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -78,5 +79,19 @@ public class AccountController {
         Map<String, Integer> response = Map.of("userId", userId);
 
         return new ResponseEntity<>(response, headers, HttpStatus.OK);
+    }
+
+    /**
+     * メール重複確認をする。
+     * 
+     * @param RegisterUserForm
+     */
+    @GetMapping("/check-email")
+    @ResponseStatus(HttpStatus.OK)
+    public void checkEmail(@RequestBody RegisterUserForm form) {
+        User findByEmail = userService.findByEmail(form.getEmail());
+        if (findByEmail != null) {
+            throw new ConflictException("入力されたメールアドレスは既に登録されています");
+        }
     }
 }

--- a/src/main/java/com/example/raha/controller/AccountController.java
+++ b/src/main/java/com/example/raha/controller/AccountController.java
@@ -85,7 +85,7 @@ public class AccountController {
     /**
      * メール重複確認をする。
      * 
-     * @param RegisterUserForm
+     * @param CheckEmailForm
      */
     @GetMapping("/check-email")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/example/raha/controller/AccountController.java
+++ b/src/main/java/com/example/raha/controller/AccountController.java
@@ -19,6 +19,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.core.AuthenticationException;
 import com.example.raha.error.invalidAuthenticationException;
+import com.example.raha.form.CheckEmailForm;
 import com.example.raha.form.LoginForm;
 
 import com.example.raha.service.SecurityUserService;
@@ -88,7 +89,7 @@ public class AccountController {
      */
     @GetMapping("/check-email")
     @ResponseStatus(HttpStatus.OK)
-    public void checkEmail(@RequestBody RegisterUserForm form) {
+    public void checkEmail(@RequestBody CheckEmailForm form) {
         User findByEmail = userService.findByEmail(form.getEmail());
         if (findByEmail != null) {
             throw new ConflictException("入力されたメールアドレスは既に登録されています");

--- a/src/main/java/com/example/raha/form/CheckEmailForm.java
+++ b/src/main/java/com/example/raha/form/CheckEmailForm.java
@@ -1,0 +1,13 @@
+package com.example.raha.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CheckEmailForm {
+
+    private String email;
+}


### PR DESCRIPTION
## 概要 :bulb:

> この変更で何をしたか、簡潔に。

メール重複API追加

## 観点 :eye:

> レビューで何を見てほしいか。

API仕様書通りの設計になっているか
おかしなコードや無駄なコードがないか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

■通常時
①下記のURLをPOSTMANに入力（GET）
http://localhost:8080/check-email
②下記をBodyに記載
{    
   "email" : "xxx@example.com"
}
③200が出ることを確認

■メール重複時
①下記のURLをPOSTMANに入力（GET）
http://localhost:8080/check-email
②下記をBodyに記載
{    
   "email" : "demo_user@example.com"
}
③409で下記がBodyに返されているのを確認
{
    "message": "入力されたメールアドレスは既に登録されています"
}

## 関連する Issue :memo:

> 関連する Issue へのリンク。

http://18.183.155.92/issues/139

## 補足情報 :notes:

> 補足情報があれば記載。